### PR TITLE
feat: 우선순위 변경 시 선점 스케줄링 반영

### DIFF
--- a/pintos/threads/.test_status
+++ b/pintos/threads/.test_status
@@ -1,1 +1,3 @@
+priority-preempt PASS
 alarm-single FAIL
+alarm-priority PASS

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -442,7 +442,32 @@ thread_wakeUp(int64_t ticks)
 /* Sets the current thread's priority to NEW_PRIORITY. */
 void
 thread_set_priority (int new_priority) {
-	thread_current ()->priority = new_priority;
+	
+	// 현재 스레드의 priority를 변경 
+	struct thread *curr_t = thread_current();
+  	curr_t->priority = new_priority;	
+	
+	// ready 리스트 확인하기 전 intr 비활성화
+	intr_disable();
+	
+	if(!list_empty(&ready_list))
+	{
+		// ready_list에 있는 첫 스레드
+		struct thread *next_t = list_entry(list_front(&ready_list), struct thread, elem);
+	
+		if(curr_t->priority < next_t->priority)
+		{
+			// priority 확인 후 intr 활성화
+			intr_enable();
+			
+			// yield() 안에서 intr 비활성화, ready에 넣음, ready 상태로 변경, 스케줄 실행, intr 활성화 진행
+			thread_yield();
+		}
+	}
+	else
+	{
+		intr_enable();
+	}
 }
 
 /* Returns the current thread's priority. */

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -234,7 +234,12 @@ thread_create (const char *name, int priority,
 	/* Add to run queue. */
 	thread_unblock (t);
 
+	//NICK - thread_unblock(t) 안에서 ready_list에 우선순위에 맞게 넣어주기 때문에 thread_create에서는 따로 우선순위 비교해서 넣어줄 필요 X
+	if(t -> priority > thread_current() -> priority) //t는 새로 만들어진 스레드, thread_current()는 현재 실행 중인 스레드
+		thread_yield(); //새 스레드가 우선순위가 높다면 thred_yield*()를 호출해서 현재 스레드가 cpu에서 양보하도록 함
+
 	return tid;
+	//NICK 
 }
 
 /* Puts the current thread to sleep.  It will not be scheduled
@@ -341,8 +346,16 @@ thread_yield (void) {
 	old_level = intr_disable ();
 	
 	// 현재 스레드가 idle_thread가 아니라면
-	if (curr != idle_thread)
-		list_push_back (&ready_list, &curr->elem);
+	// if (curr != idle_thread)
+	// 	list_push_back (&ready_list, &curr->elem);
+	
+	
+	// NICK - ready_list에 현재 스레드를 우선순위에 맞게 넣어주기 
+	//&ready_list는 cpu에 할당받기 위해 준비된 스레드들이 대기하는 리스트이므로 우선순위에 맞게 큐에 
+	//&curr->elem는 현재 스레드의 list_elem 구조체로, ready_list에 삽입될 때 사용됨
+	//compare_priority는 우선순위 비교 함수, NULL은 보조 인자(사용하지 않으므로 NULL)
+	list_insert_ordered(&ready_list, &curr->elem, compare_priority, NULL);
+	// NICK
 
 	// do_schedule 쓰지 않고 현재 스레드 상태를 바로 준비 상태로 변경
 	curr->status = THREAD_READY; 
@@ -369,7 +382,8 @@ static bool compare_priority (const struct list_elem *a, const struct list_elem 
 	struct thread *thread_a = list_entry(a, struct thread, elem);
 	struct thread *thread_b = list_entry(b, struct thread, elem);
 
-	return thread_a->priority > thread_b->priority;
+	return thread_a->priority > thread_b->priority; 
+	// 큰 숫자가 앞으로 오는 compare함수, ready_list는 우선순위가 높은 순서대로 정렬되어야 하기 때문에
 }
 
 void


### PR DESCRIPTION
## 무엇을 변경했나요?

`thread_set_priority()`에서 현재 스레드의 priority를 변경한 뒤,
ready 상태의 스레드 중 더 높은 priority를 가진 스레드가 있으면
즉시 `thread_yield()` 하도록 수정했습니다.

## 왜 변경했나요?

우선순위를 변경해도 스케줄링에 바로 반영되지 않으면
더 높은 priority의 스레드가 ready 상태로 있어도
현재 스레드가 계속 실행될 수 있습니다.

priority 변경 결과가 즉시 반영되도록 해
선점 스케줄링 동작을 맞추기 위해 수정했습니다.

## 어떻게 구현했나요?

- `thread_set_priority()`에서 현재 스레드의 priority 갱신
- `ready_list`가 비어 있지 않은 경우 맨 앞 스레드의 priority 확인
- 현재 스레드보다 높은 priority의 ready 스레드가 있으면 `thread_yield()` 호출
- ready 스레드가 없는 경우 인터럽트를 다시 활성화하도록 분기 추가

## 테스트

- [ ] 단위 테스트 추가/수정
- [ ] 통합 테스트 추가/수정
- [ ] 수동 테스트 완료

## 체크리스트

- [x] 프로젝트 스타일 가이드 준수
- [x] 자기 리뷰 완료
- [ ] 복잡한 로직에 주석 추가
- [ ] 문서 업데이트
- [ ] 빌드/실행 추가 확인