### PR TITLE
refactor: process 인자 파싱 구현 정리

### DIFF
--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -603,6 +603,7 @@ load (const char *file_name, struct intr_frame *if_) {
 	size_t user_argv_bytes = argc * sizeof *user_argv;
 	user_argv_page_cnt = DIV_ROUND_UP (user_argv_bytes, PGSIZE);
 	user_argv = palloc_get_multiple (0, user_argv_page_cnt);
+	
 	if (user_argv == NULL)
 		goto done;
 
@@ -640,9 +641,9 @@ load (const char *file_name, struct intr_frame *if_) {
 	}
 
 	/* 3. NULL 포인터 센티널 넣기 */
-	if_->rsp -= 8; 
+	if_->rsp -= sizeof(char *); 
 	
-	memset((void *)if_->rsp, 0, 8);
+	memset((void *)if_->rsp, 0, sizeof(char *));
 
 	//memcpy(if_->rsp, 0, 8);
 	// 우연히 맞는 코드, 원래 로직이라면 이 코드가 아님
@@ -652,18 +653,18 @@ load (const char *file_name, struct intr_frame *if_) {
 	for(int i = argc - 1; i >= 0; i--)
 	{
 		/* 주소는 8바이트로 크기 고정 */
-		if_->rsp -= 8;
+		if_->rsp -= sizeof(char *);
 		
 		/* 값을 크기만큼 복사해서 rsp에 넣는다 */
-		memcpy((void *)if_->rsp, &user_argv[i], 8);
+		memcpy((void *)if_->rsp, &user_argv[i], sizeof(char *));
 	}
 	
 	/* 아래에서 push한 문자열 시작 주소를 push 해주기 위해 따로 저장 */
 	argv_rsp = if_->rsp;
 
 	/* 5. 가짜 반환 주소 0 넣기 */
-	if_->rsp -= 8;
-	memset((void *)if_->rsp, 0 , 8);
+	if_->rsp -= sizeof(char *);
+	memset((void *)if_->rsp, 0 , sizeof(char *));
 
 	//hex_dump (if_->rsp, (void *) if_->rsp, USER_STACK - if_->rsp, true);
 


### PR DESCRIPTION
## 변경 내용
- `dev2-JUDY-load-only` 브랜치의 `process.c`와 현재 브랜치 구현을 비교 리뷰했습니다.
- `load()`의 인자 파싱과 스택 구성 로직에서 현재 브랜치 구현을 기준안으로 유지하도록 정리했습니다.
- 동적 `argv` 할당 방식, 실행 파일명 기준 스레드 이름 설정, 불필요한 디버그 출력 제거 방향을 유지했습니다.

## 반영 이유
- 고정 길이 `argv[64]` 배열은 인자 수가 많아질 때 범위 초과 위험이 있습니다.
- 실행 경로에 남아 있는 `hex_dump()` 같은 디버그 출력은 테스트 결과와 로그 가독성을 해칠 수 있습니다.
- 실행 파일명 기준으로 스레드 이름을 유지하는 쪽이 종료 메시지와 디버깅 결과를 더 일관되게 만듭니다.

## 기대 효과
- 긴 커맨드라인 입력에 대한 안정성이 더 좋아집니다.
- 사용자 프로그램 실행 시 불필요한 출력이 줄어듭니다.
- `process.c`의 인자 파싱 구현 의도가 더 명확해집니다.

## 참고
- 관련 커밋: `0cd56e1`